### PR TITLE
Fix possible simultaneous CWND increase and decrease by DCTCP sender

### DIFF
--- a/sim/dctcp.cpp
+++ b/sim/dctcp.cpp
@@ -59,7 +59,7 @@ DCTCPSrc::receivePacket(Packet& pkt)
 	_pkts_seen = 0;
 	_pkts_marked = 0;
 
-	if (_alfa>0){
+	if (_alfa>0 && (pkt.flags() & ECN_ECHO)){
 	    _cwnd = _cwnd * (1-_alfa/2);
 
 	    if (_cwnd<_mss)

--- a/sim/tcp.cpp
+++ b/sim/tcp.cpp
@@ -130,7 +130,7 @@ TcpSrc::receivePacket(Packet& pkt)
     simtime_picosec ts;
     TcpAck *p = (TcpAck*)(&pkt);
     TcpAck::seq_t seqno = p->ackno();
-
+    bool marked=pkt.flags() & ECN_ECHO;
 #ifdef MODEL_RECEIVE_WINDOW
     if (_mSrc)
 	_mSrc->receivePacket(pkt);
@@ -218,7 +218,8 @@ TcpSrc::receivePacket(Packet& pkt)
       
 	    _last_acked = seqno;
 	    _dupacks = 0;
-	    inflate_window();
+	    if(!marked)
+	       inflate_window();
 
 	    if (_cwnd>_maxcwnd) {
 		_cwnd = _maxcwnd;


### PR DESCRIPTION
In the original DCTCP code there are two issues 

1. CWND may decrease whenever an ACK  ( ECN marked or unmarked ) is received if _alfa > 0 since _alfa may not be zero when unmarked ACK is received (dctcp.cpp line 62).  The fix for this is to decrease the DCTCP CWND  for ECN marked ACK when the rest of the conditions are satisfied. 
2. CWND may decrease and also increase  by DCTCP sender when ECN marked ACK is received.  To solve this  inflate_window() ( tcp.cpp line 221) should be called only for unmarked ACKs for DCTCP sender.
